### PR TITLE
调整formatter，与最新版本的echarts保持一致

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,4 @@ npm-debug.log
 .DS_Store
 test/coverage
 doc/api
-bat-ria.sublime-project
-bat-ria.sublime-workspace
+*.sublime-*

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ npm-debug.log
 .DS_Store
 test/coverage
 doc/api
+bat-ria.sublime-project
+bat-ria.sublime-workspace

--- a/src/ui/PieChart.js
+++ b/src/ui/PieChart.js
@@ -64,8 +64,8 @@ define(
                             normal: {
                                 label: {
                                     position: 'outer',
-                                    formatter: function (a, b, c, d) {
-                                        return (d - 0).toFixed(0) + '%';
+                                    formatter: function (a) {
+                                        return (a.percent - 0).toFixed(0) + '%';
                                     }
                                 },
                                 labelLine: {


### PR DESCRIPTION
echarts 的此次提交改变了 formatter 的参数形式：https://github.com/ecomfe/echarts/commit/151e7a87a661ccd1e4cab69d325f65ad7c28cb8e#diff-135257ccc0491223777def3de1ebba18

注：本次 pull request 并未考虑与之前版本的 echarts 和谐共处。