### PR TITLE
调整formatter，与最新版本的echarts保持一致

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ npm-debug.log
 .DS_Store
 test/coverage
 doc/api
+*.sublime*

--- a/src/ui/PieChart.js
+++ b/src/ui/PieChart.js
@@ -65,6 +65,10 @@ define(
                                 label: {
                                     position: 'outer',
                                     formatter: function () {
+                                        // 由于 echarts 此次提交：
+                                        // https://github.com/ecomfe/echarts/commit/151e7a87a661ccd1e4cab69d325f65ad7c28cb8e#diff-135257ccc0491223777def3de1ebba18，
+                                        // 导致此处 formatter 回调函数的参数发生了变化。
+                                        // 为了保证与最新版本 echarts 兼容，做一下 arguments 参数判断
                                         var args = arguments;
                                         if (args.length === 1) {
                                             return (args[0].percent - 0).toFixed(0) + '%';

--- a/src/ui/PieChart.js
+++ b/src/ui/PieChart.js
@@ -64,8 +64,14 @@ define(
                             normal: {
                                 label: {
                                     position: 'outer',
-                                    formatter: function (a) {
-                                        return (a.percent - 0).toFixed(0) + '%';
+                                    formatter: function () {
+                                        var args = arguments;
+                                        if (args.length === 1) {
+                                            return (args[0].percent - 0).toFixed(0) + '%';
+                                        }
+                                        if (args.length === 4) {
+                                            return (args[3] - 0).toFixed(0) + '%';
+                                        }
                                     }
                                 },
                                 labelLine: {

--- a/src/ui/PieChart.js
+++ b/src/ui/PieChart.js
@@ -64,8 +64,8 @@ define(
                             normal: {
                                 label: {
                                     position: 'outer',
-                                    formatter: function (a, b, c, d) {
-                                        return (d - 0).toFixed(0) + '%';
+                                    formatter: function (a) {
+                                        return (a.percent - 0).toFixed(0) + '%';
                                     }
                                 },
                                 labelLine: {


### PR DESCRIPTION
echarts 的此次提交改变了 formatter 的参数形式：https://github.com/ecomfe/echarts/commit/151e7a87a661ccd1e4cab69d325f65ad7c28cb8e#diff-135257ccc0491223777def3de1ebba18

注：本次 pull request 并未考虑与之前版本的 echarts 和谐共处。