### PR TITLE
Image支持无后缀名路径

### DIFF
--- a/src/ui/Image.js
+++ b/src/ui/Image.js
@@ -173,7 +173,7 @@ define(
         Image.prototype.checkExtension = function () {
             var match = /\.\w+?(?=\?|#|$)/.exec(this.url);
             if (!match) {
-                return false;
+                return true;
             }
 
             var extension = match[0];


### PR DESCRIPTION
业务上要显示类似这种图片： `http://t10.baidu.com/it/u=3023925161,818185570&fm=77&src=1009`
所以改成无后缀名时跳过检查~